### PR TITLE
Remove Condition to Export Only PSA Titles

### DIFF
--- a/export-metrics.py
+++ b/export-metrics.py
@@ -57,18 +57,17 @@ def create_workbook():
 def add_torrents_to_workbook(workbook, torrents):
 	worksheet = workbook['Torrents']
 	for torrent in torrents:
-		if "PSA" in torrent.name:
-			new_row = (
-				torrent.name.replace(".mkv",""),
-				format_bytes(torrent.size),
-				datetime.datetime.fromtimestamp(torrent.added_on).strftime("%d %B %Y, %I:%M %p"),
-				format_seconds(torrent.seeding_time),
-				format_bytes(torrent.uploaded),
-				round(torrent.ratio, 2),
-				"None" if torrent.category == "" else torrent.category,
-				torrent.hash,
-			)
-			worksheet.append(new_row)
+		new_row = (
+			torrent.name.replace(".mkv",""),
+			format_bytes(torrent.size),
+			datetime.datetime.fromtimestamp(torrent.added_on).strftime("%d %B %Y, %I:%M %p"),
+			format_seconds(torrent.seeding_time),
+			format_bytes(torrent.uploaded),
+			round(torrent.ratio, 2),
+			"None" if torrent.category == "" else torrent.category,
+			torrent.hash,
+		)
+		worksheet.append(new_row)
 	return(workbook)
 
 def save_workbook(workbook):

--- a/export-metrics.py
+++ b/export-metrics.py
@@ -45,6 +45,7 @@ def create_workbook():
 		'Uploaded',
 		'Ratio',
 		'Category',
+		'Path',
 		'Hash',
 	)
 	worksheet.append(header_row)	
@@ -65,6 +66,7 @@ def add_torrents_to_workbook(workbook, torrents):
 			format_bytes(torrent.uploaded),
 			round(torrent.ratio, 2),
 			"None" if torrent.category == "" else torrent.category,
+			torrent.save_path,
 			torrent.hash,
 		)
 		worksheet.append(new_row)


### PR DESCRIPTION
## Summary by Sourcery

Remove the condition that only exports PSA titles, now exporting all torrents in the workbook

New Features:
- Add 'Path' column to the exported torrent metrics

Enhancements:
- Modify torrent export to include all torrents instead of filtering for PSA titles